### PR TITLE
[SCSB-155] build with Numpy 2.0 release candidate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'stregion'
 description = 'python parser for ds9 region files'
 readme = 'README.md'
-requires-python = '>=3.7'
+requires-python = '>=3.9'
 license = { file = 'LICENSE.txt' }
 authors = [{ name = 'Jae-Joon Lee', email = 'lee.j.joon@gmail.com' }]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ['version']
 [build-system]
 requires = [
     'Cython',
-    'numpy>=2.0.0rc2',
+    'numpy>=2.0',
     'setuptools >=61',
     'setuptools_scm[toml] >=3.4',
     'wheel',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ['version']
 [build-system]
 requires = [
     'Cython',
-    'numpy',
+    'numpy>=2.0.0rc2',
     'setuptools >=61',
     'setuptools_scm[toml] >=3.4',
     'wheel',


### PR DESCRIPTION
resolves [SCSB-155](https://jira.stsci.edu/browse/SCSB-155)

Numpy 2.0 is scheduled for release on June 19th. Due to the C ABI updates, Python projects that build C extensions are required to build against Numpy 2.0 in order to use Numpy 2.0 in runtime.
This is backwards-compatible with Numpy versions in runtime as far back as `1.26`

this PR pins `numpy>=2.0` in `build-system.requires`
> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot: