### PR TITLE
Ignore int conversion error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ CYTHON_SOURCE_FILES = ["_region_filter.pyx"]
 EXTRA_COMPILE_ARGS = [
     "-Wall",
     "-Wextra",
+    "-Wno-int-conversion",
     "-std=gnu99",
 ]
 


### PR DESCRIPTION
* Cython is comparing the return value of import_array() with an integer
* Actual return type is a void pointer
* Recent versions of gcc and clang treat this as an error... correctly.
* This will not be fixed until cython changes their code generation logic