### PR TITLE
unpin python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'stregion'
 description = 'python parser for ds9 region files'
 readme = 'README.md'
-requires-python = '>=3.9,<3.13'
+requires-python = '>=3.9'
 license = { file = 'LICENSE.txt' }
 authors = [{ name = 'Jae-Joon Lee', email = 'lee.j.joon@gmail.com' }]
 classifiers = [


### PR DESCRIPTION
We are beginning testing of drizzlepac with python 3.13. While enabling testing, an unknown error is occurring when installing drizzlepac dependencies including stregion.

While the goal is to test drizzlepac with python 3.13, we are also trying to diagnose the installation issue. 