### PR TITLE
[SCSB-237] build Stable ABI3 wheels with `Py_LIMITED_API`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3"
+          pip-install: build
       - if: ${{ runner.os == 'Linux' }}
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
@@ -37,7 +38,6 @@ jobs:
         with:
           package-dir: ./
           output-dir: dist/
-      - run: pip install build
       - run: python -m build --sdist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,31 +1,71 @@
 name: build
 
 on:
-  release:
-    types: [ released ]
   pull_request:
+  release:
+    types: [released]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   build:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@d9b81a07e789d1b1921ab5fe33de2ddcbbd02c3f  # v2.3.0
-    with:
-      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
-      targets: |
-        # Linux wheels
-        - cp3*-manylinux_x86_64
-        # MacOS wheels
-        - cp3*-macosx_x86_64
-        # ARM64 wheels
-        - cp3*-macosx_arm64
-        # Windows wheels
-        - cp3*-win_amd64
-        - cp3*-win32
-      sdist: true
-      test_command: python -c "from stregion import _region_filter"
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3"
+      - if: ${{ runner.os == 'Linux' }}
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        with:
+          package-dir: ./
+          output-dir: dist/
+      - run: pip install build
+      - run: python -m build --sdist
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-${{ runner.os }}-${{ runner.arch }}
+          path: ./dist/
+  publish:
+    if: (github.event_name == 'release') && (github.event.action == 'released')
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    # To add required reviewers before deployment,
+    # edit the protection rules in GitHub Settings:
+    # Settings > Environments > pypi > Add required reviewers
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stregion
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: dist*
+          path: dist/
+          merge-multiple: true
+      - uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: "dist/*"
+      # To upload to PyPI without a token, add this workflow file as a Trusted Publisher in the project settings on the PyPI website
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ write_to = 'stregion/version.py'
 where = ['.']
 
 [tool.cibuildwheel]
-build = "cp39-*"  # build for CPython 3.9 Stable API
-skip = ["cp3*t-*"]  # explicitly skip free-threaded builds
+build = [
+    "cp39-*",  # build for CPython 3.9 Stable API
+    "cp3*t-*",  # build for free-threaded Python
+]
 test-command = "python -c 'from stregion import _region_filter'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,5 @@ where = ['.']
 
 [tool.cibuildwheel]
 build = "cp39-*"  # build for CPython 3.9 Stable API
-skip = ["cp3??t-*"]  # explicitly skip free-threaded builds
+skip = ["cp3*t-*"]  # explicitly skip free-threaded builds
 test-command = "python -c 'from stregion import _region_filter'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,6 @@ write_to = 'stregion/version.py'
 where = ['.']
 
 [tool.cibuildwheel]
-skip = ["cp*t-*"]
+build = "cp39-*"  # build for CPython 3.9 Stable API
+skip = ["cp3??t-*"]  # explicitly skip free-threaded builds
+test-command = "python -c 'from stregion import _region_filter'"

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ EXTRA_COMPILE_ARGS = [
     "-Wno-int-conversion",
     "-std=gnu99",
 ]
+MACROS = [
+    ("Py_LIMITED_API", 0x03090000),  # PY_VERSION_HEX for 3.9
+]
 
 if sys.platform.startswith("win"):
     EXTRA_COMPILE_ARGS = []
@@ -41,7 +44,8 @@ extensions = [
             numpy_include,
         ],
         extra_compile_args=EXTRA_COMPILE_ARGS,
+        define_macros=MACROS,
     ),
 ]
 
-setup(ext_modules=cythonize(extensions))
+setup(ext_modules=cythonize(extensions), options={'bdist_wheel': {'py_limited_api': 'cp39'}})

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 import os
 import sys
+import sysconfig
 import warnings
 
-from setuptools import setup, Extension
 from Cython.Build import cythonize
+from setuptools import Extension, setup
+
+FREE_THREADED_PYTHON = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
 
 
 try:
@@ -26,9 +29,9 @@ EXTRA_COMPILE_ARGS = [
     "-Wno-int-conversion",
     "-std=gnu99",
 ]
-MACROS = [
-    ("Py_LIMITED_API", 0x03090000),  # PY_VERSION_HEX for 3.9
-]
+MACROS = []
+if not FREE_THREADED_PYTHON:
+    MACROS.append(("Py_LIMITED_API", 0x03090000))  # PY_VERSION_HEX for 3.9
 
 if sys.platform.startswith("win"):
     EXTRA_COMPILE_ARGS = []
@@ -45,7 +48,12 @@ extensions = [
         ],
         extra_compile_args=EXTRA_COMPILE_ARGS,
         define_macros=MACROS,
+        py_limited_api=not FREE_THREADED_PYTHON,
     ),
 ]
 
-setup(ext_modules=cythonize(extensions), options={'bdist_wheel': {'py_limited_api': 'cp39'}})
+SETUPTOOLS_OPTIONS = {}
+if not FREE_THREADED_PYTHON:
+    SETUPTOOLS_OPTIONS["bdist_wheel"] = {"py_limited_api": "cp39"}
+
+setup(ext_modules=cythonize(extensions), options=SETUPTOOLS_OPTIONS)


### PR DESCRIPTION
Resolves [SCSB-237](https://jira.stsci.edu/browse/SCSB-237)

building against the Limited API means we can build just ONE wheel (in this case for Python 3.9) and it should work on all future Python versions: https://docs.python.org/3/c-api/stable.html#limited-c-api